### PR TITLE
Fix spectate mode only showing a part of the game

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -607,5 +607,11 @@ window.addEventListener('resize', resize);
 function resize() {
     player.screenWidth = c.width = global.screenWidth = global.playerType == 'player' ? window.innerWidth : global.gameWidth;
     player.screenHeight = c.height = global.screenHeight = global.playerType == 'player' ? window.innerHeight : global.gameHeight;
+
+    if (global.playerType == 'spectate') {
+        player.x = global.gameWidth / 2;
+        player.y = global.gameHeight / 2;
+    }
+
     socket.emit('windowResized', { screenWidth: global.screenWidth, screenHeight: global.screenHeight });
 }


### PR DESCRIPTION
In spectate mode, the center of view was not being set properly, therefore the spectator could only see a part of the game. Fixed that by updating the player coordinates (center of view) on 'resize' events.
