### PR TITLE
Fix gulpfile watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ gulp.task('build-server', ['lint'], function () {
 });
 
 gulp.task('watch', ['build'], function () {
-  gulp.watch(['src/client/**/*.*'], ['build-client', 'move-client']);
+  gulp.watch(['src/client/**/*.*'], ['build-client']);
   gulp.watch(['src/server/*.*', 'src/server/**/*.js'], ['build-server']);
   gulp.start('run-only');
 });
@@ -61,11 +61,10 @@ gulp.task('todo', ['lint'], function() {
 
 gulp.task('run', ['build'], function () {
     nodemon({
-        delay: 10,
-        script: './server/server.js',
-        cwd: "./bin/",
-        args: ["config.json"],
-        ext: 'html js css'
+        delay: 2,
+        script: 'bin/server/server.js',
+        watch: 'bin/server',
+        ext: 'js'
     })
     .on('restart', function () {
         util.log('server restarted!');
@@ -74,11 +73,10 @@ gulp.task('run', ['build'], function () {
 
 gulp.task('run-only', function () {
     nodemon({
-        delay: 10,
-        script: './server/server.js',
-        cwd: "./bin/",
-        args: ["config.json"],
-        ext: 'html js css'
+        delay: 2,
+        script: 'bin/server/server.js',
+        watch: 'bin/server',
+        ext: 'js'
     })
     .on('restart', function () {
         util.log('server restarted!');


### PR DESCRIPTION
The watch task wasn't working due to a miss configuration. For some reason nodemon was ignoring the 'cwd' option, resulting in a "File not found" when trying to run bin/server.js.

Also, a server restart was being triggered multiple times when a source code file changed. Fixing that by restricting nodemon's watch path to the 'bin/server' directory (since changes in files from 'bin/client' or 'src' do not require a server restart).
