### PR TITLE
Add a key to toggle chat visibility

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -190,6 +190,9 @@ function setupSocket(socket) {
         if (global.mobile) {
             document.getElementById('gameAreaWrapper').removeChild(document.getElementById('chatbox'));
         }
+        if (global.playerType === 'spectate') {
+            $('#chatbox').hide();
+        }
 		c.focus();
     });
 

--- a/src/client/js/canvas.js
+++ b/src/client/js/canvas.js
@@ -148,6 +148,9 @@ class Canvas {
         else if (key === global.KEY_CHAT) {
             document.getElementById('chatInput').focus();
         }
+        else if (key === global.KEY_TOGGLE_CHAT) {
+            $('#chatbox').toggle();
+        }
     }
 }
 

--- a/src/client/js/global.js
+++ b/src/client/js/global.js
@@ -3,6 +3,7 @@ module.exports = {
     KEY_ESC: 27,
     KEY_ENTER: 13,
     KEY_CHAT: 13,
+    KEY_TOGGLE_CHAT: 99,
     KEY_FIREFOOD: 119,
     KEY_SPLIT: 32,
     KEY_LEFT: 37,


### PR DESCRIPTION
Press 'c' to toggle the chat. In spectate mode, the chat starts
invisible. Fixes issue #18.
