### PR TITLE
Adicionar ranking geral ao fim da partida

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,8 +22,8 @@
     "adminPass": "DEFAULT",
     "gameMode": "robot",
     "robotModeConf": {
-        "maxPlayers": 4,
-        "timeLimit": 20,
+        "maxPlayers": 2,
+        "timeLimit": 180,
         "respawnTime": 5,
         "killPoints": 1,
         "timeToKick": 0,

--- a/config.json
+++ b/config.json
@@ -22,8 +22,8 @@
     "adminPass": "DEFAULT",
     "gameMode": "robot",
     "robotModeConf": {
-        "maxPlayers": 2,
-        "timeLimit": 180,
+        "maxPlayers": 4,
+        "timeLimit": 20,
         "respawnTime": 5,
         "killPoints": 1,
         "timeToKick": 0,
@@ -41,5 +41,6 @@
     "newPlayerInitialPosition": "farthest",
     "massLossRate": 1,
     "minMassLoss": 50,
-    "mergeTimer": 15
+    "mergeTimer": 15,
+    "rankingDisplayLimit": 10
 }


### PR DESCRIPTION
Adiciona um ranking geral ao final da partida. O número de jogadores mostrados no ranking pode ser configurado em rankingDisplayLimit no arquivo config.json.

Atende a issue #25, embora a parte do cliente precise de melhoria.
